### PR TITLE
Fix the dumpPoints function when running on influxdb v1

### DIFF
--- a/src/vuegraf/vuegraf.py
+++ b/src/vuegraf/vuegraf.py
@@ -18,6 +18,7 @@ import traceback
 from threading import Event
 import argparse
 import pytz
+import pprint
 
 # InfluxDB v1
 import influxdb
@@ -133,7 +134,10 @@ def dumpPoints(label, usageDataPoints):
     if args.debug:
         debug(label)
         for point in usageDataPoints:
-            debug('  {}'.format(point.to_line_protocol()))
+            if influxVersion == 2:
+                debug('  {}'.format(point.to_line_protocol()))
+            else:
+                debug(f'  {pprint.pformat(point)}')
 
 def getLastDBTimeStamp(chanName, pointType, fooStartTime, fooStopTime, fooHistoryFlag):
     timeStr = ''


### PR DESCRIPTION
This function uses the to_line_protocol() method which only exists on the influxdb_client.Point object, resulting in:

AttributeError: 'dict' object has no attribute 'to_line_protocol'

Updated dumpPoints to also support dumping points created for influxdb v1